### PR TITLE
Use absolute time for "percentage of round elapsed" calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A file that contains all the numeric constants.
 
 - The score needed to win at the end (`TARGET`)
 - How many rounds are needed (and therefore how many words must be fetched) (`ROUNDS`)
+- How many seconds are in each round (`ROUND_DURATION`)
 - The character code for the enter key, which is 13. (`ENTER`)
 - The character code for the backspace key, which is 8. (`BACKSPACE`)
 
@@ -170,6 +171,10 @@ This is actually counter-intuitive. The `points` is the percentage of the round 
 #### `penalty`
 
 The number which, when subtracted from `points`, is the round's points. This starts at 30 because `100 - 30 = 0`.
+
+#### `startedAt`
+
+The high-quality timestamp since the page loaded (roughly) when the game initially started.
 
 #### `text`
 

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,5 +1,7 @@
 const ROUNDS = 5
 const TARGET = 200
 
+const ROUND_DURATION = 10
+
 const BACKSPACE = 8
 const ENTER = 13

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -19,7 +19,10 @@ getWords().then(words => {
 		drawWord(CTX, C, gameState.points, words[gameState.round], "green", "red")
 		drawTotal(CTX, C, gameState.total, "yellow", "turquoise")
 		
-		const delta = now - (gameState.startedAt || now)
+		
+		if(gameState.startedAt === null) gameState.startedAt = now
+		
+		const delta = now - gameState.startedAt
 		
 		gameState.points = 100 * (delta / ROUND_DURATION)
 		

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -24,7 +24,7 @@ getWords().then(words => {
 		
 		const delta = now - gameState.startedAt
 		
-		gameState.points = 100 * (delta / ROUND_DURATION)
+		gameState.points = 100 * (1 - delta / ROUND_DURATION)
 		
 		if(Math.floor(gameState.points) <= 0) {
 			nextRound()

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -24,7 +24,7 @@ getWords().then(words => {
 		
 		const delta = now - gameState.startedAt
 		
-		gameState.points = 100 * (1 - delta / ROUND_DURATION)
+		gameState.points = 100 * (1 - delta / (ROUND_DURATION * 10e3))
 		
 		if(Math.floor(gameState.points) <= 0) {
 			nextRound()

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -4,13 +4,14 @@ const gameState = {
 	points: 100, // 0 <= 100
 	penalty: 30, // 30 => 
 	text: "",
+	startedAt: null,
 }
 
 const C = document.querySelector("canvas")
 const CTX = C.getContext("2d")
 
 getWords().then(words => {
-	const drawFrame = () => {
+	const drawFrame = now => {
 		if(gameState.round >= ROUNDS || gameState.total <= 0) return roundCheck(CTX, C);
 		
 		drawBackground(CTX, C, "black")
@@ -18,20 +19,22 @@ getWords().then(words => {
 		drawWord(CTX, C, gameState.points, words[gameState.round], "green", "red")
 		drawTotal(CTX, C, gameState.total, "yellow", "turquoise")
 		
-		gameState.points -= 0.1
+		const delta = now - (gameState.startedAt || now)
+		
+		gameState.points = 100 * (delta / ROUND_DURATION)
 		
 		if(Math.floor(gameState.points) <= 0) {
 			nextRound()
 		}
 		
-		requestAnimationFrame(drawFrame);
-		
 		CTX.font = "20px monospace"
 		CTX.fillStyle = "white"
 		CTX.fillText(gameState.text, C.width / 5 + 10, C.height / 2 + 90)
+		
+		requestAnimationFrame(drawFrame)
 	}
 	
-	drawFrame()
+	requestAnimationFrame(drawFrame)
   
 	document.addEventListener("keypress", e => {
 		const key = e.which || e.keyCode || e.charCode


### PR DESCRIPTION
Adds a constant to change the duration of rounds, too, which is awesome! This changes the documentation to document that constant, and updates a function to calculate how much time has elapsed since the game started (stored in `delta`) and then figures out how much that is compared to how much time the round should take.

Resolves #7 